### PR TITLE
Refactor(#25): cors 도메인 수정

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -8,7 +8,7 @@ http {
     # HTTP → HTTPS 리디렉션
     server {
         listen 80;
-        server_name zezeone-sf.p-e.kr;
+        server_name zezeone-sf.site;
 
         location / {
             return 301 https://$host$request_uri;
@@ -23,10 +23,10 @@ http {
     # HTTPS 처리 (SSL)
     server {
         listen 443 ssl;
-        server_name zezeone-sf.p-e.kr;
+        server_name zezeone-sf.site;
 
-        ssl_certificate     /etc/letsencrypt/live/zezeone-sf.p-e.kr/fullchain.pem;
-        ssl_certificate_key /etc/letsencrypt/live/zezeone-sf.p-e.kr/privkey.pem;
+        ssl_certificate     /etc/letsencrypt/live/zezeone-sf.site/fullchain.pem;
+        ssl_certificate_key /etc/letsencrypt/live/zezeone-sf.site/privkey.pem;
 
         location / {
             proxy_pass http://spring_app;

--- a/src/main/java/com/backend/core/config/security/CorsProperties.java
+++ b/src/main/java/com/backend/core/config/security/CorsProperties.java
@@ -2,19 +2,20 @@ package com.backend.core.config.security;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 import java.util.List;
 
-@ConfigurationProperties(prefix = "cors.allowed")
 @Getter
-@RequiredArgsConstructor
+@Setter
+@ConfigurationProperties(prefix = "cors.allowed")
 public class CorsProperties {
-    private final List<String> paths;
-    private final List<String> origins;
-    private final List<String> methods;
-    private final List<String> headers;
-    private final List<String> exposedHeaders;
-    private final Long maxAge;
-    private final Boolean credentials;
+    private List<String> paths;
+    private List<String> origins;
+    private List<String> methods;
+    private List<String> headers;
+    private List<String> exposedHeaders;
+    private Long maxAge;
+    private Boolean credentials;
 }

--- a/src/main/java/com/backend/core/config/security/WebMvcConfig.java
+++ b/src/main/java/com/backend/core/config/security/WebMvcConfig.java
@@ -20,7 +20,7 @@ public class WebMvcConfig implements WebMvcConfigurer {
         registry.addMapping("/**")
                 .allowedOrigins("https://zezeone-sf.site", "http://localhost:3000")
                 .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
-                .allowedHeaders("*")
+                .allowedHeaders("Content-Type", "Authorization", "X-Requested-With", "Cookie")
                 .allowCredentials(true);
     }
 }

--- a/src/main/java/com/backend/core/config/security/WebMvcConfig.java
+++ b/src/main/java/com/backend/core/config/security/WebMvcConfig.java
@@ -2,6 +2,7 @@ package com.backend.core.config.security;
 
 import com.backend.core.interceptor.SessionCheckInterceptor;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
@@ -13,6 +14,13 @@ public class WebMvcConfig implements WebMvcConfigurer {
                 .addPathPatterns("/api/admin/**")
                 .excludePathPatterns("/api/login");
     }
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+                .allowedOrigins("https://zezeone-sf.site", "http://localhost:3000")
+                .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+                .allowedHeaders("*")
+                .allowCredentials(true);
+    }
 }
-
-


### PR DESCRIPTION
## #️⃣연관된 이슈

>#25

## 📝작업 내용

> 도메인 구매에 따라 CORS 수정


## 💬리뷰 요구사항(선택)

>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 모든 경로에 대해 CORS 정책이 명시적으로 적용되어, https://zezeone-sf.site 및 http://localhost:3000 도메인에서의 접근이 허용됩니다.
  * CORS 설정이 수정되어 HTTP 메서드와 허용 헤더가 구체적으로 지정되고, 자격 증명 지원이 활성화되었습니다.

* **버그 수정**
  * 서버 도메인이 zezeone-sf.site로 변경되어 SSL 인증서 및 관련 설정이 최신 도메인에 맞게 업데이트되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->