### PR TITLE
Feat(#31): 불량 수 반환 api를 작성한다.

### DIFF
--- a/src/main/java/com/backend/core/config/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/backend/core/config/exception/GlobalExceptionHandler.java
@@ -92,10 +92,12 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler(DefectRateException.class)
-    public ResponseEntity<Map<String, Object>> handleDefectRateException(DefectRateException ex) {
-        Map<String, Object> error = new HashMap<>();
-        error.put("code", ex.getCode());
-        error.put("message", ex.getMessage());
+    public ResponseEntity<ErrorResponse> handleDefectRateException(DefectRateException ex) {
+        ErrorResponse error = ErrorResponse.of(
+                ex.getStatus().value(),
+                ex.getCode(),
+                ex.getMessage()
+        );
         return ResponseEntity.status(ex.getStatus()).body(error);
     }
 

--- a/src/main/java/com/backend/core/config/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/backend/core/config/exception/GlobalExceptionHandler.java
@@ -3,6 +3,7 @@ package com.backend.core.config.exception;
 import com.backend.auth.exception.UnauthorizedException;
 import com.backend.core.presentation.ErrorResponse;
 import com.backend.dashboard.exception.DashboardException;
+import com.backend.dashboard.exception.DefectRateException;
 import com.backend.dashboard.exception.ProductStatisticsException;
 import com.backend.dashboard.exception.UniformityException;
 import com.backend.product.exception.ProductListException;
@@ -11,6 +12,9 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.*;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.HashMap;
+import java.util.Map;
 
 @Slf4j
 @RestControllerAdvice
@@ -84,6 +88,14 @@ public class GlobalExceptionHandler {
                 ex.getCode(),
                 ex.getMessage()
         );
+        return ResponseEntity.status(ex.getStatus()).body(error);
+    }
+
+    @ExceptionHandler(DefectRateException.class)
+    public ResponseEntity<Map<String, Object>> handleDefectRateException(DefectRateException ex) {
+        Map<String, Object> error = new HashMap<>();
+        error.put("code", ex.getCode());
+        error.put("message", ex.getMessage());
         return ResponseEntity.status(ex.getStatus()).body(error);
     }
 

--- a/src/main/java/com/backend/dashboard/application/DashboardDefectRateService.java
+++ b/src/main/java/com/backend/dashboard/application/DashboardDefectRateService.java
@@ -1,0 +1,80 @@
+package com.backend.dashboard.application;
+
+import com.backend.dashboard.domain.ProductQualityDashboardRepository;
+import com.backend.dashboard.exception.DefectRateException;
+import com.backend.dashboard.presentation.dto.DefectRateResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.YearMonth;
+import java.time.format.DateTimeFormatter;
+import java.util.*;
+
+@Service
+@RequiredArgsConstructor
+public class DashboardDefectRateService {
+
+    private final ProductQualityDashboardRepository repository;
+    private static final DateTimeFormatter DATE_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+
+    public DefectRateResponse getTodayDefectCount() {
+        try {
+            LocalDate today = LocalDate.now();
+            LocalDateTime start = today.atStartOfDay();
+            LocalDateTime end = start.plusDays(1);
+            long count = repository.countByLabelAndUploadDateBetween("X", start, end);
+            return new DefectRateResponse(today.format(DATE_FORMAT), count);
+        } catch (Exception e) {
+            throw new DefectRateException(
+                    "DEFECT_001",
+                    "오늘의 불량 데이터를 집계하는 중 오류가 발생했습니다.",
+                    HttpStatus.INTERNAL_SERVER_ERROR
+            );
+        }
+    }
+
+    public List<DefectRateResponse> getWeeklyDefectCounts() {
+        try {
+            List<DefectRateResponse> result = new ArrayList<>();
+            LocalDate today = LocalDate.now();
+            for (int i = 3; i >= 0; i--) {
+                LocalDate start = today.minusWeeks(i).with(java.time.DayOfWeek.MONDAY);
+                LocalDate end = start.plusDays(7);
+                long count = repository.countByLabelAndUploadDateBetween("X", start.atStartOfDay(), end.atStartOfDay());
+                result.add(new DefectRateResponse(start.format(DATE_FORMAT), count));
+            }
+            return result;
+        } catch (Exception e) {
+            throw new DefectRateException(
+                    "DEFECT_002",
+                    "주간 불량 데이터를 집계하는 중 오류가 발생했습니다.",
+                    HttpStatus.INTERNAL_SERVER_ERROR
+            );
+        }
+    }
+
+    public List<DefectRateResponse> getMonthlyDefectCounts() {
+        try {
+            List<DefectRateResponse> result = new ArrayList<>();
+            YearMonth currentMonth = YearMonth.now();
+            for (int i = 2; i >= 0; i--) {
+                YearMonth month = currentMonth.minusMonths(i);
+                LocalDate start = month.atDay(1);
+                LocalDateTime startTime = start.atStartOfDay();
+                LocalDateTime endTime = month.plusMonths(1).atDay(1).atStartOfDay();
+                long count = repository.countByLabelAndUploadDateBetween("X", startTime, endTime);
+                result.add(new DefectRateResponse(start.format(DATE_FORMAT), count));
+            }
+            return result;
+        } catch (Exception e) {
+            throw new DefectRateException(
+                    "DEFECT_003",
+                    "월별 불량 데이터를 집계하는 중 오류가 발생했습니다.",
+                    HttpStatus.INTERNAL_SERVER_ERROR
+            );
+        }
+    }
+}

--- a/src/main/java/com/backend/dashboard/application/DashboardService.java
+++ b/src/main/java/com/backend/dashboard/application/DashboardService.java
@@ -4,7 +4,6 @@ import com.backend.dashboard.domain.ProductQualityDashboard;
 import com.backend.dashboard.domain.ProductQualityDashboardRepository;
 import com.backend.dashboard.exception.DashboardException;
 import com.backend.dashboard.presentation.dto.DashboardSummaryResponse;
-import com.backend.dashboard.presentation.dto.DefectRateResponse;
 import com.backend.dashboard.presentation.dto.QualityTrendResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -84,38 +83,6 @@ public class DashboardService {
             String dateStr = date.toString();
             long[] cnt = map.getOrDefault(dateStr, new long[]{0, 0, 0});
             result.add(new QualityTrendResponse(dateStr, cnt[0], cnt[1], cnt[2]));
-        }
-        return result;
-    }
-
-    // 불량률 ("X" 레이블 기준)
-    public List<DefectRateResponse> getDefectRates() {
-        List<ProductQualityDashboard> list = getLastWeekData();
-        LocalDate todaySeoul = LocalDate.now(SEOUL_ZONE);
-
-        if (list.isEmpty()) {
-            throw new DashboardException(
-                    "DASHBOARD_DEFECT_DATA_NOT_FOUND",
-                    "최근 7일간 불량률 데이터를 집계할 수 없습니다.",
-                    HttpStatus.NOT_FOUND
-            );
-        }
-
-        Map<String, int[]> map = new TreeMap<>();
-        for (ProductQualityDashboard pq : list) {
-            LocalDate localDate = convertToSeoulDate(pq.getUploadDate());
-            String day = localDate.toString();
-            map.putIfAbsent(day, new int[]{0, 0});
-            if ("X".equalsIgnoreCase(pq.getLabel())) map.get(day)[0]++;
-            map.get(day)[1]++;
-        }
-        List<DefectRateResponse> result = new ArrayList<>();
-        for (int i = DAYS_TO_TRACK - 1; i >= 0; i--) {
-            LocalDate date = todaySeoul.minusDays(i);
-            String dateStr = date.toString();
-            int[] arr = map.getOrDefault(dateStr, new int[]{0, 0});
-            double rate = arr[1] == 0 ? 0.0 : ((double) arr[0] / arr[1]) * 100;
-            result.add(new DefectRateResponse(dateStr, Math.round(rate * 10.0) / 10.0));
         }
         return result;
     }

--- a/src/main/java/com/backend/dashboard/domain/ProductQualityDashboardRepository.java
+++ b/src/main/java/com/backend/dashboard/domain/ProductQualityDashboardRepository.java
@@ -11,4 +11,5 @@ public interface ProductQualityDashboardRepository extends MongoRepository<Produ
     List<ProductQualityDashboard> findByUploadDateAfter(LocalDateTime date);
     List<ProductQualityDashboard> findAllByUploadDateBetween(LocalDateTime start, LocalDateTime end);
     List<ProductQualityDashboard> findByLabelNot(String label);
+    long countByLabelAndUploadDateBetween(String label, LocalDateTime start, LocalDateTime end);
 }

--- a/src/main/java/com/backend/dashboard/exception/DefectRateException.java
+++ b/src/main/java/com/backend/dashboard/exception/DefectRateException.java
@@ -1,0 +1,22 @@
+package com.backend.dashboard.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class DefectRateException extends RuntimeException {
+    private final String code;
+    private final HttpStatus status;
+
+    public DefectRateException(String code, String message, HttpStatus status) {
+        super(message);
+        this.code = code;
+        this.status = status;
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    public HttpStatus getStatus() {
+        return status;
+    }
+}

--- a/src/main/java/com/backend/dashboard/presentation/DashboardController.java
+++ b/src/main/java/com/backend/dashboard/presentation/DashboardController.java
@@ -25,8 +25,4 @@ public class DashboardController implements DashboardSwagger {
         return ResponseEntity.ok(dashboardService.getQualityTrends());
     }
 
-    @Override
-    public ResponseEntity<List<DefectRateResponse>> getDefectRates() {
-        return ResponseEntity.ok(dashboardService.getDefectRates());
-    }
 }

--- a/src/main/java/com/backend/dashboard/presentation/DashboardDefectRateController.java
+++ b/src/main/java/com/backend/dashboard/presentation/DashboardDefectRateController.java
@@ -1,0 +1,33 @@
+package com.backend.dashboard.presentation;
+
+import com.backend.dashboard.presentation.dto.DefectRateResponse;
+import com.backend.dashboard.presentation.swagger.DashboardDefectRateSwagger;
+import com.backend.dashboard.application.DashboardDefectRateService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequiredArgsConstructor
+public class DashboardDefectRateController implements DashboardDefectRateSwagger {
+
+    private final DashboardDefectRateService service;
+
+    @Override
+    public ResponseEntity<DefectRateResponse> getTodayDefectCount() {
+        return ResponseEntity.ok(service.getTodayDefectCount());
+    }
+
+    @Override
+    public ResponseEntity<List<DefectRateResponse>> getWeeklyDefectCounts() {
+        return ResponseEntity.ok(service.getWeeklyDefectCounts());
+    }
+
+    @Override
+    public ResponseEntity<List<DefectRateResponse>> getMonthlyDefectCounts() {
+        return ResponseEntity.ok(service.getMonthlyDefectCounts());
+    }
+}

--- a/src/main/java/com/backend/dashboard/presentation/dto/DashboardSummaryResponse.java
+++ b/src/main/java/com/backend/dashboard/presentation/dto/DashboardSummaryResponse.java
@@ -2,9 +2,12 @@ package com.backend.dashboard.presentation.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Data
 @AllArgsConstructor
+@NoArgsConstructor
 public class DashboardSummaryResponse {
     private long totalProducts;
     private long aQualityProducts;

--- a/src/main/java/com/backend/dashboard/presentation/dto/DefectRateResponse.java
+++ b/src/main/java/com/backend/dashboard/presentation/dto/DefectRateResponse.java
@@ -7,5 +7,5 @@ import lombok.Data;
 @AllArgsConstructor
 public class DefectRateResponse {
     private String date;         // yyyy-MM-dd
-    private double defectRate;   // 불량률 (%) 소수점
+    private long xCount;      // 불량 개수
 }

--- a/src/main/java/com/backend/dashboard/presentation/swagger/DashboardDefectRateSwagger.java
+++ b/src/main/java/com/backend/dashboard/presentation/swagger/DashboardDefectRateSwagger.java
@@ -1,0 +1,28 @@
+package com.backend.dashboard.presentation.swagger;
+
+import com.backend.dashboard.presentation.dto.DefectRateResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import java.util.List;
+import java.util.Map;
+
+@Tag(name = "대시보드")
+@RequestMapping("/api/admin/dashboard/defect-rate")
+public interface DashboardDefectRateSwagger {
+
+    @Operation(summary = "오늘 불량 개수", description = "오늘 하루 동안 발생한 불량 개수를 반환합니다.")
+    @GetMapping("/daily")
+    ResponseEntity<DefectRateResponse> getTodayDefectCount();
+
+    @Operation(summary = "주별 불량 개수", description = "최근 4주간의 주별 불량 개수를 반환합니다.")
+    @GetMapping("/weekly")
+    ResponseEntity<List<DefectRateResponse>> getWeeklyDefectCounts();
+
+    @Operation(summary = "월별 불량 개수", description = "최근 3개월간의 월별 불량 개수를 반환합니다.")
+    @GetMapping("/monthly")
+    ResponseEntity<List<DefectRateResponse>> getMonthlyDefectCounts();
+}

--- a/src/main/java/com/backend/dashboard/presentation/swagger/DashboardSwagger.java
+++ b/src/main/java/com/backend/dashboard/presentation/swagger/DashboardSwagger.java
@@ -21,8 +21,4 @@ public interface DashboardSwagger {
     @Operation(summary = "일별 품질 추이", description = "최근 7일간 등급별(고수율/저수율) 판별 추이")
     @GetMapping("/trend")
     ResponseEntity<List<QualityTrendResponse>> getQualityTrends();
-
-    @Operation(summary = "불량률 추이", description = "최근 7일간 불량률(%) 추이")
-    @GetMapping("/defect-rate")
-    ResponseEntity<List<DefectRateResponse>> getDefectRates();
 }

--- a/src/main/java/com/backend/dashboard/presentation/swagger/UniformitySwagger.java
+++ b/src/main/java/com/backend/dashboard/presentation/swagger/UniformitySwagger.java
@@ -9,7 +9,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 
 import java.util.List;
 
-@Tag(name = "대시보드", description = "제품별 균일도/클러스터/등급 목록 반환 API")
+@Tag(name = "대시보드")
 @RequestMapping("/api/admin/dashboard/uniformity")
 public interface UniformitySwagger {
 

--- a/src/main/java/com/backend/product/presentation/dto/ProductQualityResponse.java
+++ b/src/main/java/com/backend/product/presentation/dto/ProductQualityResponse.java
@@ -10,7 +10,6 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 @Builder
 public class ProductQualityResponse {
-
     private String productId;
     private String imageUrl;
     private String label;          // A / B


### PR DESCRIPTION
## #️⃣연관된 이슈

> #31 

## 📝작업 내용

> 불량 수 반환 api를 작성


## 💬리뷰 요구사항(선택)

> 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 대시보드 결함률(Defect Rate) 통계(일별, 주별, 월별) 조회 API가 추가되었습니다.
  * 결함률 데이터는 결함 건수(xCount)로 제공됩니다.

* **버그 수정**
  * 일부 예외 상황에서 사용자에게 반환되는 에러 응답 형식이 개선되었습니다.

* **문서화**
  * Swagger 문서에 결함률 관련 신규 API가 추가되고, 일부 기존 설명이 정리되었습니다.

* **기타**
  * 불필요한 결함률 관련 구 API 및 필드가 제거되었습니다.
  * 일부 클래스에 기본 생성자가 추가되고, 코드 스타일이 소폭 정리되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->